### PR TITLE
Custom (or tor) proxies must have the higher priority

### DIFF
--- a/extensions/chromium/runet-censorship-bypass/src/extension-common/35-pac-kitchen-api.js
+++ b/extensions/chromium/runet-censorship-bypass/src/extension-common/35-pac-kitchen-api.js
@@ -364,7 +364,7 @@
         if (pacMods.filteredCustomsString) {
           res += `
 /******/
-/******/    const filteredCustomProxies = "; ${pacMods.filteredCustomsString}";
+/******/    const filteredCustomProxies = "${pacMods.filteredCustomsString}; ";
 /******/`;
         }
 
@@ -440,6 +440,7 @@ ${        pacMods.filteredCustomsString
 /******/      return "DIRECT";
 /******/    }
 /******/    return ` +
+        (pacMods.filteredCustomsString ? 'filteredCustomProxies + ' : '') +
         function() {
 
           if (!pacMods.ifUsePacScriptProxies) {
@@ -452,7 +453,7 @@ ${        pacMods.filteredCustomsString
           }
           return filteredPacExp + ' + ';
 
-        }() + `${pacMods.filteredCustomsString ? 'filteredCustomProxies + ' : ''}directIfAllowed;`; // Without DIRECT you will get 'PROXY CONN FAILED' pac-error.
+        }() + `directIfAllowed;`; // Without DIRECT you will get 'PROXY CONN FAILED' pac-error.
 
       }()
     }


### PR DESCRIPTION
Включить:
- Использовать прокси PAC-скрипта
- Свой локальный Tor (либо свои прокси)

При совестном использовании опций подразумевается, что свои прокси должны иметь больший приоритет (выше пропускная способность и меньше задержки). А в случае недоступности использовать встроенные (antizapret).

В итоге, собственные прокси не используются и весь трафик идет только через прокси из PAC.